### PR TITLE
mul16.z80 : a way to decrease average time ..?

### DIFF
--- a/extended/mul/mul16.z80
+++ b/extended/mul/mul16.z80
@@ -4,10 +4,18 @@
 mul16:
 ;BC*DE --> DEHL
 ; ~565.161cc for uniformly distributed BC and DE
-	ld	a,d
+	ld h,b
+	ld l,c
+	xor a		; we might not need it..? (perhaps a "rough" compare would decrease average cc ..?)
+	sbc hl,de	; BC < DE ?
+	ld h,b
+	ld l,c
+	jr nc,+_	; no, then no permutation
+	ex de,hl
+	ld b,h
+	ld c,l	
+_:	ld	a,d
 	ld	d,0
-	ld	h,b
-	ld	l,c
 	add	a,a
 	jr	c,Mul_BC_DE_DEHL_Bit14
 	add	a,a


### PR DESCRIPTION
I had this idea : maybe we could decrease average execution time by check/permutation of BC & DE  when BC < DE ..?
What do you think of it ?